### PR TITLE
Various tile rendering changes and added tile definitions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,9 @@ Layout/FirstArrayElementIndentation:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/CyclomaticComplexity:
+  Max: 7
+
 Metrics/BlockLength:
   Enabled: False
 

--- a/assets/js/app.rb
+++ b/assets/js/app.rb
@@ -5,17 +5,28 @@ require 'snabberb'
 require 'polyfill'
 
 require 'view/game'
+require 'view/tiles'
 require 'engine/player'
 require 'engine/game/base'
 require 'engine/game/g_1889'
 
 class App < Snabberb::Component
   needs :game
+  needs :page, store: true, default: 'tiles'
 
   def render
     h(:div, { props: { id: 'app' } }, [
-      h(View::Game, game: @game),
+      *tabs,
+      h(View::Game, game: @game, visible: @page == 'game'),
+      h(View::Tiles, visible: @page == 'tiles'),
     ])
+  end
+
+  def tabs
+    [
+      h(:button, { on: { click: -> { store(:page, 'game') } } }, 'Game'),
+      h(:button, { on: { click: -> { store(:page, 'tiles') } } }, 'Tiles'),
+    ]
   end
 end
 

--- a/assets/js/view/game.rb
+++ b/assets/js/view/game.rb
@@ -12,6 +12,7 @@ require 'engine/round/stock'
 module View
   class Game < Snabberb::Component
     needs :game
+    needs :visible
 
     def render_round
       h(:div, "Round: #{@round.class.name}")
@@ -31,7 +32,10 @@ module View
 
       players = @game.players.map { |player| h(Player, player: player) }
 
-      h(:div, [
+      attrs = { id: 'game' }
+      attrs[:style] = 'display: none' unless @visible
+
+      h(:div, { attrs: attrs }, [
         h(:div, 'Game test 1889'),
         h(EntityOrder, round: @round),
         render_round,

--- a/assets/js/view/hex.rb
+++ b/assets/js/view/hex.rb
@@ -17,6 +17,14 @@ module View
       pointy: [SIZE * Math.sqrt(3) / 2, SIZE * 3 / 2],
     }.freeze
 
+    COLOR = {
+      white: '#fff',
+      yellow: '#fde900',
+      green: '#71bf44',
+      brown: '#cb7745',
+      gray: '#bcbdc0',
+    }.freeze
+
     needs :hex
     needs :selected_hex_info, default: nil, store: true
     needs :role, default: :map
@@ -30,7 +38,7 @@ module View
       props = {
         attrs: {
           transform: transform,
-          fill: tile&.color || 'white',
+          fill: COLOR.fetch(tile&.color, 'white'),
           stroke: 'black',
         },
         on: { click: ->(e) { on_hex_click(e) } },

--- a/assets/js/view/tiles.rb
+++ b/assets/js/view/tiles.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'snabberb'
+
+require 'engine/tile'
+
+module View
+  class Tiles < Snabberb::Component
+    needs :visible
+
+    def render
+      attrs = { id: 'tiles' }
+      attrs[:style] = 'display: none' unless @visible
+
+      tile_ids = [
+        Engine::Tile::YELLOW.keys,
+        Engine::Tile::GREEN.keys,
+        Engine::Tile::BROWN.keys,
+        Engine::Tile::GRAY.keys,
+      ].reduce(&:+)
+
+      # TODO?: iterate over tile_ids just once
+      generic_tiles = tile_ids.reject { |id| id =~ /;/ }
+      game_tiles = tile_ids.select { |id| id =~ /;/ }
+
+      children = (generic_tiles + game_tiles).flat_map do |tile|
+        render_tile_block(tile)
+      end
+
+      h(
+        :div,
+        { attrs: attrs },
+        children,
+      )
+    end
+
+    def render_tile_block(tile_id)
+      [
+        h(:div, { style: {
+            display: 'inline-block',
+            width: '80px',
+            height: '97px',
+            'outline-style': 'solid',
+            'outline-width': 'thin',
+            'margin-top': '10px',
+            'margin-right': '1px',
+          } }, [
+            h(:div, { style: { 'text-align': 'center' } }, tile_id),
+            h(:svg, { style: { width: '100%', height: '100%' } }, [
+                h(:g, { attrs: { transform: 'scale(0.4)' } }, [
+                    h(
+                      Hex,
+                      hex: Engine::Hex.new('A1', layout: 'flat', tile: Engine::Tile.for(tile_id)),
+                      role: :tile_selector
+                    )
+                  ])
+              ])
+          ])
+      ]
+    end
+  end
+end

--- a/lib/engine/city.rb
+++ b/lib/engine/city.rb
@@ -2,14 +2,16 @@
 
 module Engine
   class City
-    attr_reader :revenue
+    attr_reader :name, :revenue, :slots
 
-    def initialize(revenue)
+    def initialize(revenue, slots = 1, name = nil)
       @revenue = revenue.to_i
+      @slots = slots.to_i
+      @name = name
     end
 
     def ==(other)
-      @revenue == other.revenue
+      (other.class == City) && (@revenue == other.revenue) && (@slots == other.slots) && (@name == other.name)
     end
   end
 end

--- a/lib/engine/game/g_1889.rb
+++ b/lib/engine/game/g_1889.rb
@@ -6,6 +6,7 @@ require 'engine/company/tile_laying'
 require 'engine/company/terrain_discount'
 require 'engine/corporation/base'
 require 'engine/game/base'
+require 'engine/game_error'
 require 'engine/hex'
 require 'engine/map'
 require 'engine/tile'
@@ -40,6 +41,18 @@ module Engine
         ]
       end
 
+      def initial_tiles
+        @initial_tiles ||= {
+          'B3' => ['1889;B3', 0],
+          'B7' => ['1889;B7', 0],
+          'C4' => ['1889;C4', 0],
+          'F9' => ['1889;F9', 0],
+          'G14' => ['1889;B3', 4],
+          'J7' => ['1889;J7', 0],
+          'K4' => ['1889;K4', 0],
+        }
+      end
+
       def init_map
         coordinates = %w[
           A8 A10 B3 B5 B7 B9 B11 C4 C6 C8 C10
@@ -52,10 +65,12 @@ module Engine
         hexes = coordinates.map do |c|
           tile =
             begin
-              Tile.for("1889;#{c}")
-            rescue GameError
+              name, rotation = initial_tiles[c]
+              Tile.for(name, rotation: rotation)
+            rescue Engine::GameError
               nil
             end
+
           Hex.new(c, layout: :flat, tile: tile)
         end
 

--- a/lib/engine/junction.rb
+++ b/lib/engine/junction.rb
@@ -2,8 +2,8 @@
 
 module Engine
   class Junction
-    def ==(_other)
-      true
+    def ==(other)
+      other.class == Junction
     end
   end
 end

--- a/lib/engine/label.rb
+++ b/lib/engine/label.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Engine
+  class Label
+    def initialize(label = nil)
+      @label = label
+    end
+
+    def to_s
+      @label.to_s
+    end
+
+    def ==(other)
+      (other.class == Label) && (@label == other.to_s)
+    end
+  end
+end

--- a/lib/engine/tile.rb
+++ b/lib/engine/tile.rb
@@ -5,12 +5,13 @@ require 'engine/town'
 require 'engine/edge'
 require 'engine/game_error'
 require 'engine/junction'
+require 'engine/label'
 require 'engine/path'
 
 module Engine
-  class Tile
+  class Tile # rubocop:disable Metrics/ClassLength
     YELLOW = {
-      '1' => 't=r:10,n:A;p=a:0,b:_0;p=a:_0,b:2;t=r:10,n:B;p=a:3,b:_1;p=a:_1,b:5',
+      '1' => 't=r:10,n:_A;p=a:0,b:_0;p=a:_0,b:2;t=r:10,n:_B;p=a:3,b:_1;p=a:_1,b:5',
       '3' => 't=r:10;p=a:0,b:_0;p=a:_0,b:5',
       '4' => 't=r:10;p=a:0,b:_0;p=a:_0,b:3',
       '5' => 'c=r:20;p=a:0,b:_0;p=a:_0,b:1',
@@ -20,26 +21,68 @@ module Engine
       '9' => 'p=a:0,b:3',
       '57' => 'c=r:20;p=a:0,b:_0;p=a:_0,b:3',
       '58' => 't=r:10;p=a:0,b:_0;p=a:_0,b:4',
-      '437' => 't=r:30;p=a:0,b:_0;p=a:_0,b:2', # 1889 Port
-      '438' => 'c=r:40;p=a:0,b:_0;p=a:_0,b:2', # 1889 Kotohira
-      '1889;C4' => 'c=r:20;p=a:2,b:_0',
-      '1889;K4' => 'c=r:30;p=a:0,b:_0;p=a:1,b:_0;p=a:2,b:_0', # v:KO
+      '437' => 't=r:30,n:Port;p=a:0,b:_0;p=a:_0,b:2',
+      '438' => 'c=r:40,n:Kotohira;p=a:0,b:_0;p=a:_0,b:2;l=H', # u: 80 JPY
+      '1889;C4' => 'c=r:20,n:Ohzu;p=a:2,b:_0',
+      '1889;K4' => 'c=r:30,n:Takamatsu;p=a:0,b:_0;p=a:1,b:_0;p=a:2,b:_0;l=T', # v:KO
     }.freeze
 
     GREEN = {
       '12' => 'c=r:30;p=a:0,b:_0;p=a:1,b:_0;p=a:5,b:_0',
       '13' => 'c=r:30;p=a:0,b:_0;p=a:2,b:_0;p=a:4,b:_0',
-      '14' => 'c=r:30;p=a:0,b:_0;p=a:2,b:_0;p=a:3,b:_0;p=a:5,b:_0', # s:2
+      '14' => 'c=r:30,s:2;p=a:0,b:_0;p=a:2,b:_0;p=a:3,b:_0;p=a:5,b:_0',
+      '15' => 'c=r:30,s:2;p=a:0,b:_0;p=a:4,b:_0;p=a:3,b:_0;p=a:5,b:_0',
       '16' => 'p=a:0,b:4;p=a:5,b:3',
       '18' => 'p=a:0,b:3;p=a:1,b:2',
+      '19' => 'p=a:5,b:1;p=a:0,b:3',
+      '20' => 'p=a:0,b:3;p=a:5,b:2',
+      '23' => 'p=a:0,b:3;p=a:0,b:4',
+      '24' => 'p=a:0,b:3;p=a:0,b:2',
+      '25' => 'p=a:0,b:2;p=a:0,b:4',
+      '26' => 'p=a:0,b:3;p=a:0,b:5',
+      '27' => 'p=a:0,b:3;p=a:3,b:4',
+      '28' => 'p=a:0,b:4;p=a:0,b:5',
+      '29' => 'p=a:0,b:4;p=a:5,b:4',
       '81A' => 'p=a:0,b:j;p=a:2,b:j;p=a:4,b:j',
-      '1889;F9' => 'c=r:30;p=a:2,b:_0;p=a:3,b:_0;p=a:4,b:_0;p=a:5,b:_0', # s:2,v:TR
+      '205' => 'c=r:30;p=a:0,b:_0;p=a:3,b:_0;p=a:4,b:_0',
+      '206' => 'c=r:30;p=a:0,b:_0;p=a:3,b:_0;p=a:5,b:_0',
+      '298' => 'c=r:40,n:_A;c=r:40,n:_B;c=r:40,n:_C;c=r:40,n:_D;l=Chi;'\
+               'p=a:1,b:_0;p=a:0,b:_1;p=a:5,b:_2;p=a:4,b:_3;'\
+               'p=a:_0,b:3;p=a:_2,b:3;p=a:_3,b:3;p=a:_1,b:3',
+      '439' => 'c=r:60,s:2,n:Kotohira;p=a:0,b:_0;p=a:2,b:_0;p=a:4,b:_0;l=H', # u: 80 JPY
+      '440' => 'c=r:40,n:Takamatsu,s:2;p=a:0,b:_0;p=a:1,b:_0;p=a:5,b:_0;l=T',
+      '1889;F9' => 'c=r:30,s:2,n:Kouchi;p=a:2,b:_0;p=a:3,b:_0;p=a:4,b:_0;p=a:5,b:_0;l=K', # v:TR
+    }.freeze
+
+    BROWN = {
+      '39' => 'p=a:1,b:5;p=a:0,b:1;p=a:5,b:0',
+      '40' => 'p=a:0,b:2;p=a:2,b:4;p=a:4,b:0',
+      '41' => 'p=a:0,b:3;p=a:3,b:4;p=a:4,b:0',
+      '42' => 'p=a:0,b:3;p=a:3,b:2;p=a:2,b:0',
+
+      '45' => 'p=a:3,b:1;p=a:1,b:5;p=a:0,b:3;p=a:5,b:0',
+      '46' => 'p=a:1,b:5;p=a:3,b:5;p=a:0,b:3;p=a:1,b:0',
+
+      '47' => 'p=a:0,b:3;p=a:3,b:5;p=a:5,b:2;p=a:2,b:0',
+
+      '448' => 'c=r:40,s:2;p=a:0,b:_0;p=a:4,b:_0;p=a:3,b:_0;p=a:5,b:_0',
+
+      '465' => 'c=r:40,s:2,n:Kouchi;p=a:2,b:_0;p=a:3,b:_0;p=a:4,b:_0;p=a:5,b:_0;l=K', # v:TR
+
+      '466' => 'c=r:60,n:Takamatsu,s:2;p=a:0,b:_0;p=a:1,b:_0;p=a:5,b:_0;l=T',
+
+      '492' => 'c=r:80,s:3,n:Kotohira;p=a:0,b:_0;p=a:1,b:_0;p=a:2,b:_0;p=a:3,b:_0;p=a:4,b:_0;p=a:5,b:_0;l=H',
+
+      '611' => 'c=r:40,s:2;p=a:0,b:_0;p=a:1,b:_0;p=a:2,b:_0;p=a:3,b:_0;p=a:4,b:_0;',
+
+      'W5' => 'c=r:50,s:6;p=a:0,b:_0;p=a:1,b:_0;p=a:2,b:_0;p=a:3,b:_0;p=a:4,b:_0;p=a:5,b:_0',
     }.freeze
 
     GRAY = {
+      '456' => 'c=r:70,s:5;p=a:0,b:_0;p=a:1,b:_0;p=a:2,b:_0;p=a:3,b:_0;p=a:4,b:_0;p=a:5,b:_0',
+      '639' => 'c=r:100,s:4;p=a:0,b:_0;p=a:1,b:_0;p=a:2,b:_0;p=a:3,b:_0;p=a:4,b:_0;p=a:5,b:_0',
       '1889;B3' => 't=r:20;p=a:0,b:_0;p=a:_0,b:5',
-      '1889;B7' => 'c=r:40;p=a:1,b:_0;p=a:3,b:_0;p=a:5,b:_0', # v:UR
-      '1889;G14' => 't=r:20;p=a:3,b:_0;p=a:_0,b:4',
+      '1889;B7' => 'c=r:40,s:2,n:Uwajima;p=a:1,b:_0;p=a:3,b:_0;p=a:5,b:_0', # v:UR
       '1889;J7' => 'p=a:1,b:5',
     }.freeze
 
@@ -50,6 +93,8 @@ module Engine
         color = :yellow
       elsif (code = GREEN[name])
         color = :green
+      elsif (code = BROWN[name])
+        color = :brown
       elsif (code = GRAY[name])
         color = :gray
       else
@@ -62,14 +107,16 @@ module Engine
     def self.decode(code)
       cache = []
 
-      code.split(';').map do |path_code|
-        type, params = path_code.split('=')
-        params = params.split(',').map { |param| param.split(':') }.to_h
-        path(type, params, cache)
+      code.split(';').map do |part_code|
+        type, params = part_code.split('=')
+
+        params = params.split(',').map { |param| param.split(':') }.to_h if params.include?(':')
+
+        part(type, params, cache)
       end
     end
 
-    def self.path(type, params, cache)
+    def self.part(type, params, cache)
       case type
       when 'p'
         params = params.map do |k, v|
@@ -85,13 +132,17 @@ module Engine
 
         Path.new(params['a'], params['b'])
       when 'c'
-        city = City.new(params['r'])
+        city = City.new(params['r'], params.fetch('s', 1), params['n'])
         cache << city
         city
       when 't'
         town = Town.new(params['r'], params['n'])
         cache << town
         town
+      when 'l'
+        label = Label.new(params)
+        cache << label
+        label
       end
     end
 
@@ -113,6 +164,10 @@ module Engine
 
     def paths
       @paths ||= @parts.select { |p| p.is_a?(Path) }
+    end
+
+    def label
+      @label ||= @parts.find { |p| p.is_a?(Label) }
     end
 
     def rotate!(clockwise)

--- a/lib/engine/town.rb
+++ b/lib/engine/town.rb
@@ -10,7 +10,7 @@ module Engine
     end
 
     def ==(other)
-      (@revenue == other.revenue) && (@name == other.name)
+      (other.class == Town) && (@revenue == other.revenue) && (@name == other.name)
     end
   end
 end

--- a/spec/lib/engine/tile_spec.rb
+++ b/spec/lib/engine/tile_spec.rb
@@ -3,20 +3,24 @@
 require './spec/spec_helper'
 require 'engine/city'
 require 'engine/junction'
+require 'engine/label'
 require 'engine/tile'
 require 'engine/town'
 
 module Engine
   describe Tile do
     let(:edge0) { Edge.new(0) }
+    let(:edge1) { Edge.new(1) }
     let(:edge2) { Edge.new(2) }
     let(:edge3) { Edge.new(3) }
     let(:edge4) { Edge.new(4) }
     let(:edge5) { Edge.new(5) }
     let(:city) { City.new(20) }
+    let(:city2) { City.new(30, 2) }
+    let(:kotohira40) { City.new(40, 1, 'Kotohira') }
     let(:town) { Town.new(10) }
-    let(:townA) { Town.new(10, 'A') }
-    let(:townB) { Town.new(10, 'B') }
+    let(:townA) { Town.new(10, '_A') }
+    let(:townB) { Town.new(10, '_B') }
     let(:junction) { Junction.new }
 
     describe '.for' do
@@ -42,6 +46,33 @@ module Engine
         expect(Tile.for('57')).to eq(
           Tile.new('57', color: :yellow, parts: [city, Path.new(edge0, city), Path.new(city, edge3)])
         )
+      end
+
+      it 'should render a city with two slots' do
+        actual = Tile.for('14')
+        expected = Tile.new(
+          '14',
+          color: :green,
+          parts: [city2, Path.new(edge0, city2), Path.new(edge2, city2), Path.new(edge3, city2), Path.new(edge5, city2)]
+        )
+
+        expect(actual).to eq(expected)
+      end
+
+      it 'should render a tile with a city and a letter (438, 1889 Kotohira)' do
+        actual = Tile.for('438')
+        expected = Tile.new(
+          '438',
+          color: :yellow,
+          parts: [
+            kotohira40,
+            Path.new(edge0, kotohira40),
+            Path.new(kotohira40, edge2),
+            Label.new('H')
+]
+        )
+
+        expect(actual).to eq(expected)
       end
 
       it 'should render a town' do


### PR DESCRIPTION
Squashed commit of the following:

commit 9a8f6720472987829bea63c0b4c9d9856d37897a
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 20:52:14 2020 -0700

    rubocop :bell:

commit a1de1e817e70e11a7dadd83b6c25fa0b5b7f648f
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 20:46:24 2020 -0700

    fix tile render error message

commit 8608b5ed3cd338a77c3058405dc70c916f00f1f4
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 20:18:10 2020 -0700

    update comments

commit 75e9ddcd1721900ea810efb99285278290d2f87f
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 20:05:47 2020 -0700

    render names for Ohzu and Uwajima

commit a5726f0101361c9ac6cd83e8a494324c5734e3e9
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 19:58:38 2020 -0700

    render city/town name if no label is rendered (eg 1889 Port)

commit 461e1d05f2eb45c4bf2d8f8786b68c9a848ff328
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 19:49:11 2020 -0700

    better table layout for tiles

commit 59bd8b85afbee373f0f7d3acd854cc8e8c327720
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 19:43:04 2020 -0700

    add missing labels to tile definitions

commit 39a26940e0c8f73f2e081a91f7a40ec86b036512
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 19:40:32 2020 -0700

    render tile labels

commit 488ea217445d4addf2540aa2e1ec12924202fa7e
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 18:48:39 2020 -0700

    change how "preprinted" map tiles are added

    for 1889, re-use B3 tile on G14 (grey, tight $20 town)

commit 9718a2a2fd8009dbd37d01560b194bb9da474513
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 18:26:44 2020 -0700

    tile colors: use "DTG" colors from kelsin

commit 48cbed21fa6efdaa1daa8f13295637982441f4f2
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 18:25:56 2020 -0700

    reorder gentle curves to avoid render glitch

commit a52e57f6eec751a2919ebe361bd29beaf4847fd1
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 18:18:04 2020 -0700

    margin between rows of tiles

commit dacebd793beeeee8ef8ea28a3d5d42bc04d68d75
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 15:47:55 2020 -0700

    add more tiles featured in 1889

commit e3d14ad18c9a982bc18d395b4711f62856b56bd0
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Thu Jan 23 15:30:53 2020 -0700

    if a tile cannot be rendered, log the error and just render its name

    much nicer than crashing the whole page

commit adf4177a30b2f0694f5801205ca83e72dfa29ac8
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Wed Jan 22 22:18:27 2020 -0700

    tiles tab: put tiles with ";" in IDs at end

commit ae0a17e48292efceb29532715e23c6a65bea7f1a
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Wed Jan 22 22:04:36 2020 -0700

    add tab switcher and tab to see all defined tiles

commit 123cab0dc0ade12f36d2ca30479f8b10807f586f
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Wed Jan 22 20:31:20 2020 -0700

    keep the build dir

commit fd4045865e358b4478c0fc76c6c57f0412aaadb5
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Tue Jan 21 21:21:09 2020 -0700

    tmp: put tiles in tile selector that show the various cities

commit 9cdd63705878dcb19ac71a4cedd41c8a1e8f3d5d
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Tue Jan 21 21:17:41 2020 -0700

    quiet, rubocop

commit 21d9e37f5d09b9390bb1af140422b336538ae4d9
Author: Michael Brandt <michaelbrandt5@gmail.com>
Date:   Tue Jan 21 21:16:25 2020 -0700

    render multiple city slots